### PR TITLE
Allow nightly builds to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,18 @@ python:
 - nightly
 - pypy
 - pypy3
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: nightly
+
 install:
 - pip install -e .
 - pip install coveralls
+
 script:
 - coverage run --source=trueskill setup.py test
+
 after_success:
 - coveralls


### PR DESCRIPTION
Right now the `nightly` CI builds are failing. It's probably a good idea to allow those to fail as there may be unstable features in there. From a CPython core committer:

> Other than `3.5-dev` and `3.6-dev`, Travis also supports `3.7-dev` and `nightly`. Since Python 3.7 is under active development I can't guarantee it's stability or that things won't change from underneath you, so I'm not going to recommend testing against it _yet_. But when we announce 3.7.0b1, expect a plea from me to add `3.7-dev` to your build matrix to help us test 3.7.0 before it's released publicly. I'm sure people will reshare this post when the time is right to do this, but when the time comes it would be fantastic if you could help us test the next feature release of CPython on top of the next bugfix releases. (And you could test against `nightly`, but that might be too bleeding edge.)

https://snarky.ca/how-to-use-your-project-travis-to-help-test-python-itself/

