### PR TITLE
add kwargs to global_env method

### DIFF
--- a/trueskill/__init__.py
+++ b/trueskill/__init__.py
@@ -661,13 +661,13 @@ def quality_1vs1(rating1, rating2, env=None):
     return env.quality([(rating1,), (rating2,)])
 
 
-def global_env():
+def global_env(**kwargs):
     """Gets the :class:`TrueSkill` object which is the global environment."""
     try:
         global_env.__trueskill__
     except AttributeError:
         # setup the default environment
-        setup()
+        setup(**kwargs)
     return global_env.__trueskill__
 
 


### PR DESCRIPTION
Using the `global_env.__trueskill__` as global env and it will be great if we can optionally pass kwargs to `global_env()` method!

e.g. we might want to pass `backend='mpmath'`
```python
ts = trueskill.global_env(backend='mpmath')
```

thx!