### PR TITLE
Update mathematics.py to ensure pi is never zero

### DIFF
--- a/trueskill/mathematics.py
+++ b/trueskill/mathematics.py
@@ -44,7 +44,7 @@ class Gaussian(object):
                 raise ValueError('sigma**2 should be greater than 0')
             pi = sigma ** -2
             tau = pi * mu
-        self.pi = pi
+        self.pi = max(pi, 1e-10)  # Ensure pi is never zero
         self.tau = tau
 
     @property


### PR DESCRIPTION
I ran into some edge cases where pi would be zero and it would crash.  Not sure if the same thing happens if you use scipy instead, but this change will ensure that if it is using its own mathematics.py then pi will always be at least something small and non-zero.